### PR TITLE
Add `astBody` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ The `force` option forces the re-execution of an already memoized function and t
 memoize.fn(fun, { force: true }).then(...
 ```
 
+#### astBody
+
+If you want to use the function AST instead the function body when generating the hash ([see serialization](#serialization)), set the option `astBody` to `true`. This allows the function source code to be reformatted without busting the cache. See https://github.com/borisdiakur/memoize-fs/issues/6 for details.
+
+```javascript
+memoize.fn(fun, { astBody: true }).then(...
+```
+
 #### noBody
 
 If for some reason you want to omit the function body when generating the hash ([see serialization](#serialization)), set the option `noBody` to `true`.

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var fs = require('fs')
 var path = require('path')
 var rmdir = require('rimraf')
 var crypto = require('crypto')
+var parseScript = require('shift-parser').parseScript
 
 module.exports = function (options) {
   // check args
@@ -50,7 +51,7 @@ module.exports = function (options) {
   function getCacheFilePath (fn, args, opt) {
     var salt = opt.salt || ''
     var source = String(fn)
-    var fnStr = (opt.noBody ? '' : source)
+    var fnStr = (opt.noBody ? '' : opt.astBody ? JSON.stringify(parseScript(source)) : source)
     var argsStr
     var hash
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = function (options) {
 
   function getCacheFilePath (fn, args, opt) {
     var salt = opt.salt || ''
-    var fnStr = (opt.noBody ? '' : String(fn))
+    var source = String(fn)
+    var fnStr = (opt.noBody ? '' : source)
     var argsStr
     var hash
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "es6-promise": "^4.0.5",
     "mkdirp": "^0.5.0",
-    "rimraf": "^2.4.0"
+    "rimraf": "^2.4.0",
+    "shift-parser": "^5.0.7"
   },
   "devDependencies": {
     "coveralls": "^2.11.0",

--- a/test/test.js
+++ b/test/test.js
@@ -927,6 +927,45 @@ describe('memoize-fs', function () {
       })
     })
 
+    describe('astBody', function () {
+      it('should cache the result of a memoized function on second execution with option astBody set to true with equivalent function ASTs', function (done) {
+        var cachePath = path.join(__dirname, '../build/cache')
+        var memoize = memoizeFs({cachePath: cachePath})
+        memoize.fn(function foo () {
+          // double quoted
+          return "string" // eslint-disable-line quotes
+        }, {
+          cacheId: 'foobar',
+          serialize: 'qux',
+          astBody: true
+        }).then(function (memFn) {
+          return memFn()
+        }).then(function (result) {
+          assert.strictEqual(result, 'string', 'expected result to strictly equal "string"')
+          return memoize.fn(function foo () {
+            // single quoted
+            return 'string'
+          }, {
+            cacheId: 'foobar',
+            serialize: 'qux',
+            astBody: true
+          })
+        }).then(function (memFn) {
+          return memFn()
+        }).then(function (result) {
+          assert.strictEqual(result, 'string', 'expected result to strictly equal "string"')
+          fs.readdir(path.join(cachePath, 'foobar'), function (err, files) {
+            if (err) {
+              done(err)
+            } else {
+              assert.strictEqual(files.length, 1, 'expected exactly one file in cache with id foobar')
+              done()
+            }
+          })
+        }).catch(done)
+      })
+    })
+
     describe('invalidate cache', function () {
       it('should recache the result of a memoized function after invalidating the cache before the second execution', function (done) {
         var cachePath = path.join(__dirname, '../build/cache')


### PR DESCRIPTION
This fixes https://github.com/borisdiakur/memoize-fs/issues/6 by using [shift-parser] to build an AST when `astBody` is set.
The AST is converted to a JSON string and used instead of the function source code during serialization.

[shift-parser]: https://github.com/shapesecurity/shift-parser-js