### PR TITLE
Doesn't work for buffer?

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -476,6 +476,36 @@ describe('memoize-fs', function () {
         }).catch(done)
       })
 
+      it('should return the cached result with the value returned by fs.readFileSync with utf8 encoding', function (done) {
+        var cachePath = path.join(__dirname, '../build/cache')
+        var memoize = memoizeFs({cachePath: cachePath})
+        const fn = function () { return fs.readFileSync(__filename, 'utf8') }
+        memoize.fn(fn).then(function (memFn) {
+          memFn(null).then(function (result) {
+            assert.strictEqual(result, fn(), 'expected result to strictly equal this file content')
+            return memFn(null)
+          }).then(function (result) {
+            assert.strictEqual(result, fn(), 'expected result to strictly equal this file content')
+            done()
+          }).catch(done)
+        }).catch(done)
+      })
+
+      it('should return the cached result with the value returned by fs.readFileSync', function (done) {
+        var cachePath = path.join(__dirname, '../build/cache')
+        var memoize = memoizeFs({cachePath: cachePath})
+        const fn = function () { return fs.readFileSync(__filename) }
+        memoize.fn(fn).then(function (memFn) {
+          memFn(null).then(function (result) {
+            assert.deepEqual(result, fn(), 'expected result to strictly equal this file content')
+            return memFn(null)
+          }).then(function (result) {
+            assert.deepEqual(result, fn(), 'expected result to strictly equal this file content')
+            done()
+          }).catch(done)
+        }).catch(done)
+      })
+
       it('should return the cached result of type object of a previously memoized function', function (done) {
         var cachePath = path.join(__dirname, '../build/cache')
         var memoize = memoizeFs({cachePath: cachePath})


### PR DESCRIPTION
When returning a buffer (from `fs.readFileSync`) the cached result isn't the same as original result. 

Edit: Actually nevermind, I don't know why I expected it to work for a result of anything other than simple objects and native values. Also it works if I just re-create the buffer with `Buffer.from(result)`