### PR TITLE
Use steno to have atomic file writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var Promise = require('es6-promise').Promise
 var mkdirp = require('mkdirp')
 var fs = require('fs')
+var steno = require('steno')
 var path = require('path')
 var rmdir = require('rimraf')
 var crypto = require('crypto')
@@ -119,7 +120,7 @@ function buildMemoizer (options) {
                     })
                   }, optExt.maxAge)
                 }
-                fs.writeFile(filePath, resultString, cb)
+                steno.writeFile(filePath, resultString, cb)
               }
 
               function processFnAsync () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "memoize-fs",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -909,8 +909,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
       "version": "1.9.2",
@@ -1871,13 +1870,12 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
+    "steno": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
+      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "graceful-fs": "4.1.11"
       }
     },
     "string-width": {
@@ -1889,6 +1887,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "es6-promise": "^4.0.5",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.0",
-    "shift-parser": "^5.0.7"
+    "shift-parser": "^5.0.7",
+    "steno": "^0.4.4"
   },
   "devDependencies": {
     "coveralls": "^2.11.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1144,29 +1144,6 @@ describe('memoize-fs', function () {
       })
     })
 
-    it('should throw an error when trying to write cache on a file without having the necessary permission', function (done) {
-      var cachePath = path.join(__dirname, '../build/cache')
-      var memoize = memoizeFs({cachePath: cachePath})
-      memoize.fn(function () { return 1 }, {cacheId: 'foobar'}).then(function (memFn) {
-        return memFn()
-      }).then(function () {
-        var files = fs.readdirSync(path.join(cachePath, 'foobar'))
-        assert.strictEqual(files.length, 1, 'expected exactly one file in cache with id foobar')
-        fs.chmodSync(path.join(cachePath, 'foobar', files[0]), 0)
-        memoize.fn(function () { return 1 }, {
-          cacheId: 'foobar',
-          force: true
-        }).then(function (memFn) {
-          return memFn()
-        }).then(function () {
-          done(Error('entered resolve handler instead of error handler'))
-        }, function (err) {
-          assert.ok(err)
-          done()
-        })
-      }).catch(done)
-    })
-
     it('should throw an error trying to invalidate cache without having the necessary permission', function (done) {
       var cachePath = path.join(__dirname, '../build/cache')
       var memoize = memoizeFs({cachePath: cachePath})


### PR DESCRIPTION
You can reproduce the problem like this:

```
var memoize = require('memoize-fs')({ cachePath: './cache' });

memoize.fn((a) => {
  return new Promise(resolve => setTimeout(resolve, 256, a));
}).then(fn => {
  var run = () => {
    fn(0).then(r => {
      if (r == null) {
        console.error('shouldnt happen', r);
      }
    });
    setImmediate(run);
  };
  run();
 });

```

fs.writeFile is not atomic, in a way, first an empty file is created and
then the file is written to in buffers. steno.writeFile instead creates
the file in a temp location and then renames it to the location that we
want the to be in the cache. This way at any moment the cache file
wouldn't be an empty or invalid json file.

The test was removed due to the fact that file permissions don't matter
in unix when removing files, and the directory permission is taken into
account now. Since now we are using steno, and it renames the file into
the location, as long as it has write permission for the directory it
can rename the file.