### PR TITLE
Pretify serialised data in cached files

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ function serialize (val) {
       circRefColl.push(value)
     }
     return value
-  })
+  },
+  4 // spece indent for prettify cached data in file
+  )
 }
 
 function deserialize (str) {
@@ -140,7 +142,7 @@ function buildMemoizer (options) {
                   resultObj = { data: r }
                   resultString = optExt.serialize(resultObj)
                 } else {
-                  resultString = '{"data":' + r + '}'
+                  resultString = '{\n   "data":' + r + '\n}'
                 }
                 if (optExt.maxAge) {
                   setTimeout(function () {


### PR DESCRIPTION
Add space indents in cache files
I use `memoize-fs` not only for the cache but also for check data between functions,
and without indents, it very hard to read