### PR TITLE
Add retryOnInvalidCache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ If for some reason you want to omit the function body when generating the hash (
 memoizer.fn(fnToMemoize, { noBody: true })
 ```
 
+### retryOnInvalidCache
+
+By default, `undefined` is returned when trying to read an invalid cache file. For example, when trying to parse an empty file with `JSON.parse`. By enabling `retryOnInvalidCache`, the memoized function will be called again, and a new cache file will be written.
+
+```js
+memoizer.fn(fnToMemoize, { retryOnInvalidCache: true })
+```
+
 ### serialize and deserialize
 
 These two options allows you to control how the serialization and deserialization process works.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export interface Options {
   force?: boolean
   astBody?: boolean
   noBody?: boolean
+  retryOnInvalidCache?: boolean
   serialize?: (val?: any) => string
   deserialize?: (val?: string) => any
 }

--- a/index.js
+++ b/index.js
@@ -82,6 +82,9 @@ function buildMemoizer (options) {
     if (opts.deserialize && typeof opts.deserialize !== 'function') {
       throw new TypeError('deserialize option of type function expected')
     }
+    if (opts.retryOnInvalidCache && typeof opts.deserialize !== 'boolean') {
+      throw new TypeError('retryOnInvalidCache option of type boolean expected')
+    }
   }
 
   // check for existing cache folder, if not found, create folder, then resolve
@@ -222,13 +225,18 @@ function buildMemoizer (options) {
                 }
               }
 
+              const parsedData = parseResult(data)
+              if (optExt.retryOnInvalidCache && parsedData === undefined) {
+                return cacheAndReturn()
+              }
+
               function retrieveAndReturn () {
                 function processFnAsync () {
-                  resolve(fnaCb.apply(null, parseResult(data)))
+                  resolve(fnaCb.apply(null, parsedData))
                 }
 
                 function processFn () {
-                  resolve(parseResult(data))
+                  resolve(parsedData)
                 }
 
                 if (optExt.async) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function buildMemoizer (options) {
     if (opts.deserialize && typeof opts.deserialize !== 'function') {
       throw new TypeError('deserialize option of type function expected')
     }
-    if (opts.retryOnInvalidCache && typeof opts.deserialize !== 'boolean') {
+    if (opts.retryOnInvalidCache && typeof opts.retryOnInvalidCache !== 'boolean') {
       throw new TypeError('retryOnInvalidCache option of type boolean expected')
     }
   }


### PR DESCRIPTION
Hey Boris, thanks for the great library!

We've encountered an issue where empty cache files are being written to the disk. In this case the library will ignore the invalid file and simply return undefined. We were bitten by this since the fact that the return type is nullable is not expressed in `index.d.ts`.

In the interest of staying backwards-compatible, I have added a `retryOnInvalidCache` option that re-runs the function if the cache file is invalid. If `parseResult` returns undefined it simply tries calls `cacheAndReturn`.

cc @joscha