### PR TITLE
Clarify README.md serialize/deserialize example for `.data` object/string mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,11 @@ to be able to cache properly the return result of memoized function containing a
 const memoizeFs = require('memoize-fs')
 const serialize = require('serialize-javascript')
 
-const deserialize = (serializedJsString) => eval(`(${serializedJsString})`)
+// if your result is an object or a string, your deserializer must expand `.data` to handle the implicit object wrapping: 
+// See: https://github.com/borisdiakur/memoize-fs/blob/34fb162c838d65e4d090730d96e1e717441b7bd6/index.js#L142-L146
+// const deserialize = (serializedJsString) => eval(`(${serializedJsString})`).data;
+
+const deserialize = (serializedJsString) => eval(`(${serializedJsString})`);
 
 const memoizer = memoizeFs({ cachePath: './cache', serialize, deserialize })
 

--- a/README.md
+++ b/README.md
@@ -253,11 +253,9 @@ to be able to cache properly the return result of memoized function containing a
 const memoizeFs = require('memoize-fs')
 const serialize = require('serialize-javascript')
 
-// if your result is an object or a string, your deserializer must expand `.data` to handle the implicit object wrapping: 
 // See: https://github.com/borisdiakur/memoize-fs/blob/34fb162c838d65e4d090730d96e1e717441b7bd6/index.js#L142-L146
-// const deserialize = (serializedJsString) => eval(`(${serializedJsString})`).data;
+const deserialize = (serializedJsString) => eval(`(${serializedJsString})`).data;
 
-const deserialize = (serializedJsString) => eval(`(${serializedJsString})`);
 
 const memoizer = memoizeFs({ cachePath: './cache', serialize, deserialize })
 


### PR DESCRIPTION
I'm not sure what the best fix to the README is, I just provided an example fix that draws attention to the issue, feel free to close this PR without merging if there's a better solution. I actually think we might _always_ need to use .data, in which case, the [current tests for this functionality](https://github.com/borisdiakur/memoize-fs/blob/master/test/test.js#L109) should actually be failing.

https://github.com/borisdiakur/memoize-fs/blob/34fb162c838d65e4d090730d96e1e717441b7bd6/index.js#L142-L146

Lines 142-146 here show the behavior w.r.t. wrapping a serialized object in an outer `{ data }` object, which results in the example being broken for at least object or string serializations (though that else makes it look like it must just never work?).
