### PR TITLE
Instead of Promise<Promise<T>>, return Promise<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ export default function buildMemoizer(
   fn: <FN extends (...args: never) => unknown>(
     fn: FN,
     opt?: Partial<MemoizerOptions>
-  ) => Promise<(...args: Parameters<FN>) => Promise<ReturnType<FN>>>
+  ) => Promise<(...args: Parameters<FN>) => EnsurePromise<ReturnType<FN>>>
   getCacheFilePath: (
     fn: (...args: never) => unknown,
     args: unknown[],
@@ -164,6 +164,8 @@ export default function buildMemoizer(
   ) => string
   invalidate: (cacheId?: string) => Promise<void>
 }
+
+type EnsurePromise<T> = T extends PromiseLike<unknown> ? T : Promise<T>;
 ```
 
 ## Options

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin typescript",
     "lint": "eslint .",
-    "test": "npm run lint && npm run coverage",
+    "test": "npm run lint && tsc --noEmit && npm run coverage",
     "open-coverage": "open coverage/lcov-report/index.ts.html",
     "publish-coverage": "npm run coverage && coveralls < coverage/lcov.info",
     "coverage": "vitest run --coverage"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,5 +5,5 @@ export default {
   output: {
     file: 'dist/index.mjs',
   },
-  plugins: [typescript()],
+  plugins: [typescript({ include: ['src/index.ts'] })],
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1430,4 +1430,19 @@ describe('memoize-fs', () => {
       assert.ok(throws)
     })
   })
+
+  describe('typing', () => {
+    it('should not double-wrap Promise<Promise<T>>', async () => {
+      const cachePath = FIXTURE_CACHE
+      const memoize = memoizeFs({ cachePath })
+
+      const syncFunction: () => number= () => 1;
+      const asyncFunction: () => Promise<number> = async () => 1;
+
+      let memFn: () => Promise<number>;
+      memFn = await memoize.fn(syncFunction);
+      memFn = await memoize.fn(asyncFunction);
+      memFn;
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,9 +405,11 @@ export default function buildMemoizer(
       await initCache(memoizerOptions.cachePath || '')
       return memoizeFn(fn as never, opt) as unknown as (
         ...args: Parameters<FN>
-      ) => Promise<ReturnType<FN>>
+      ) => EnsurePromise<ReturnType<FN>>
     },
     getCacheFilePath: getCacheFilePathBound,
     invalidate: invalidateCache,
   }
 }
+
+type EnsurePromise<T> = T extends PromiseLike<unknown> ? T : Promise<T>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   },
-  "include": ["src/index.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
In the second commit, where I add tests, I had to change some of the `tsconfig.json` settings so that the test file also gets typechecked. I verified (diffed) that the output in the `dist` directory is not changed by this second commit.