### PR TITLE
Do not minify (mangle) identifiers in bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,7 @@ export default defineConfig({
       ],
     },
   },
+  esbuild: {
+    minifyIdentifiers: false,
+  }
 });


### PR DESCRIPTION
Without this, we get the following in `dist/index.js`:

```js
const x1 = {
  0: "Unexpected token",
  // ...
};
class I2 extends SyntaxError {
  constructor(i, n, e, t, ...o) {
    const l = "[" + n + ":" + e + "]: " + x1[t].replace(/%(\d+)/g, (f, c) => o[c]);
    super(`${l}`), this.index = i, this.line = n, this.column = e, this.description = l, this.loc = {
      line: n,
      column: e
    };
  }
}
```

With this change, we get

```js
const errorMessages = {
  0: "Unexpected token",
  // ...
};
class ParseError extends SyntaxError {
  constructor(startindex, line, column, type, ...params) {
    const message = "[" + line + ":" + column + "]: " + errorMessages[type].replace(/%(\d+)/g, (_, i) => params[i]);
    super(`${message}`), this.index = startindex, this.line = line, this.column = column, this.description = message, this.loc = {
      line,
      column
    };
  }
}
```

This should make for better error messages, as we aren't limited by bandwidth in Node.