### PR TITLE
Use TypeScript's Awaited utility type instead of our custom EnsurePromise type

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ export default function buildMemoizer(
   fn: <FN extends (...args: never) => unknown>(
     fn: FN,
     opt?: Partial<MemoizerOptions>
-  ) => Promise<(...args: Parameters<FN>) => EnsurePromise<ReturnType<FN>>>
+  ) => Promise<(...args: Parameters<FN>) => Promise<Awaited<ReturnType<FN>>>>
   getCacheFilePath: (
     fn: (...args: never) => unknown,
     args: unknown[],
@@ -164,8 +164,6 @@ export default function buildMemoizer(
   ) => string
   invalidate: (cacheId?: string) => Promise<void>
 }
-
-type EnsurePromise<T> = T extends PromiseLike<unknown> ? T : Promise<T>;
 ```
 
 ## Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -405,11 +405,9 @@ export default function buildMemoizer(
       await initCache(memoizerOptions.cachePath || '')
       return memoizeFn(fn as never, opt) as unknown as (
         ...args: Parameters<FN>
-      ) => EnsurePromise<ReturnType<FN>>
+      ) => Promise<Awaited<ReturnType<FN>>>
     },
     getCacheFilePath: getCacheFilePathBound,
     invalidate: invalidateCache,
   }
 }
-
-type EnsurePromise<T> = T extends PromiseLike<unknown> ? T : Promise<T>;


### PR DESCRIPTION
I learned about [Awaited\<T>](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) just now, and thought I'd improve my patch from a few days ago, as it seems more elegant and concise to use `Awaited` here.